### PR TITLE
update git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This is the abbreviated checklist for installing and using the bootloader:
 You can clone the repository from GitHub:
 
 ```
-$ git clone git@github.com:embeddedartistry/ariadne-bootloader.git
+$ git clone https://github.com/embeddedartistry/ariadne-bootloader
 ```
 
 You can also download a zip archive of the repository from [the GitHub repository page](https://github.com/embeddedartistry/ariadne-bootloader).


### PR DESCRIPTION
There are issues with `git clone git@github.com:embeddedartistry/ariadne-bootloader.git`

Following message is displayed on running the command on all Windows, Linux and MacOS
```
Cloning into 'ariadne-bootloader'...
The authenticity of host 'github.com (13.234.210.38)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no/[fingerprint])? y
Please type 'yes', 'no' or the fingerprint: yes
Warning: Permanently added 'github.com,13.234.210.38' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

`git clone https://github.com/embeddedartistry/ariadne-bootloader` works without any issues
