### PR TITLE
Add a new menu item showing EEPROM save/erase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Bootloader binary files for different versions can be found on the [Releases](ht
 	1. [Programming Hardware Requirements](#programming-hardware-requirements)
 	2. [Connecting Pins](#connecting-pins)
 	3. [Programming with Arduino IDE](#programming-with-arduino-ide)
+		1. [EEPROM Erase Settings](#eeprom-erase-settings)
 	4. [Programming with AVRDUDE](#programming-with-avrdude)
 1. [Compiling Applications](#compiling-applications)
 1. [Flashing Applications via Serial](#flashing-applications-via-serial)
@@ -228,6 +229,18 @@ $ ln -s ~/src/ariadne-bootloader/ ./ariadne
 Once the `ariadne-bootloader` folder is placed in the `hardware/` folder, Arduino will detect it. Restart the IDE if it is already open. You should now see the Ariadne bootloader show up in the board list.
 
 ![Image showing the Ariadne bootloader in boards](docs/boards.png "Ariadne Listed in Boards")
+
+### EEPROM Erase Settings
+
+By default, bootloader updates will erase the contents of the EEPROM. Because the Ariadne EEPROM layout is different from the default layout, this approach is advisable.
+
+The project now features support for preserving the contents of the EEPROM when updating the bootloader. This is desirable if you're already using Ariadne and need to update a previously configured device to a new version.
+
+In the Arduino IDE, there is an entry called "Erase EEPROM?" in the "Tools" menu. You can select "Erase" (default) to erase the EEPROM contents when the bootloader is flashed, or "Save" to preserve the contents.
+
+![Image showing the Erase/Save EEPROM menu](docs/erase_eeprom/png "Erase Menu")
+
+If you are manually flashing the application or need to specify fuse settings, use a high_fuse setting of `0xD8` to erase, and `0xD0` to preserve.
 
 ## Atmel Studio Installation
 

--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -1,4 +1,5 @@
 menu.version=Version
+menu.eeprom=Erase EEPROM?
 
 ##############################################################
 
@@ -11,7 +12,6 @@ ariadne328D.upload.speed=115200
 
 ariadne328D.bootloader.tool=arduino:avrdude
 ariadne328D.bootloader.low_fuses=0xFF
-ariadne328D.bootloader.high_fuses=0xD8
 ariadne328D.bootloader.extended_fuses=0x05
 ariadne328D.bootloader.unlock_bits=0x3F
 ariadne328D.bootloader.lock_bits=0x0F
@@ -21,6 +21,13 @@ ariadne328D.build.f_cpu=16000000L
 ariadne328D.build.core=arduino:arduino
 ariadne328D.build.variant=arduino:standard
 ariadne328D.build.board=AVR_DUEMILANOVE
+
+## Save EEPROM Settings
+## --------------------
+ariadne328D.menu.eeprom.erase=Erase
+ariadne328D.menu.eeprom.erase.bootloader.high_fuses=0xD8
+ariadne328D.menu.eeprom.save=Save
+ariadne328D.menu.eeprom.save.bootloader.high_fuses=0xD0
 
 ## standard bootloader
 ## ---------------------------------------------
@@ -44,7 +51,6 @@ ariadne328UW.upload.speed=115200
 
 ariadne328UW.bootloader.tool=arduino:avrdude
 ariadne328UW.bootloader.low_fuses=0xFF
-ariadne328UW.bootloader.high_fuses=0xD8
 ariadne328UW.bootloader.extended_fuses=0x05
 ariadne328UW.bootloader.unlock_bits=0x3F
 ariadne328UW.bootloader.lock_bits=0x0F
@@ -55,6 +61,12 @@ ariadne328UW.build.core=arduino:arduino
 ariadne328UW.build.variant=arduino:standard
 ariadne328UW.build.board=AVR_UNO
 
+## Save EEPROM Settings
+## --------------------
+ariadne328UW.menu.eeprom.erase=Erase
+ariadne328UW.menu.eeprom.erase.bootloader.high_fuses=0xD8
+ariadne328UW.menu.eeprom.save=Save
+ariadne328UW.menu.eeprom.save.bootloader.high_fuses=0xD0
 
 ## standard bootloader for Arduino Uno with Wiznet W5100 chip
 ## ---------------------------------------------
@@ -98,7 +110,6 @@ ariadne328E.upload.speed=115200
 
 ariadne328E.bootloader.tool=arduino:avrdude
 ariadne328E.bootloader.low_fuses=0xFF
-ariadne328E.bootloader.high_fuses=0xD8
 ariadne328E.bootloader.extended_fuses=0x05
 ariadne328E.bootloader.unlock_bits=0x3F
 ariadne328E.bootloader.lock_bits=0x0F
@@ -109,6 +120,13 @@ ariadne328E.build.f_cpu=16000000L
 ariadne328E.build.core=arduino:arduino
 ariadne328E.build.variant=arduino:standard
 ariadne328E.build.board=AVR_ETHERNET
+
+## Save EEPROM Settings
+## --------------------
+ariadne328E.menu.eeprom.erase=Erase
+ariadne328E.menu.eeprom.erase.bootloader.high_fuses=0xD8
+ariadne328E.menu.eeprom.save=Save
+ariadne328E.menu.eeprom.save.bootloader.high_fuses=0xD0
 
 ##############################################################
 
@@ -122,7 +140,6 @@ ariadne2560MW.upload.speed=115200
 
 ariadne2560MW.bootloader.tool=arduino:avrdude
 ariadne2560MW.bootloader.low_fuses=0xFF
-ariadne2560MW.bootloader.high_fuses=0xD8
 ariadne2560MW.bootloader.extended_fuses=0xFD
 ariadne2560MW.bootloader.unlock_bits=0x3F
 ariadne2560MW.bootloader.lock_bits=0x0F
@@ -132,6 +149,13 @@ ariadne2560MW.build.f_cpu=16000000L
 ariadne2560MW.build.core=arduino:arduino
 ariadne2560MW.build.variant=arduino:mega
 ariadne2560MW.build.board=AVR_MEGA2560
+
+## Save EEPROM Settings
+## --------------------
+ariadne2560MW.menu.eeprom.erase=Erase
+ariadne2560MW.menu.eeprom.erase.bootloader.high_fuses=0xD8
+ariadne2560MW.menu.eeprom.save=Save
+ariadne2560MW.menu.eeprom.save.bootloader.high_fuses=0xD0
 
 ## standard bootloader for Mega 2560 with Wiznet W5100 chip
 ## ---------------------------------------------
@@ -175,7 +199,6 @@ ariadne1284W.upload.speed=115200
 
 ariadne1284W.bootloader.tool=arduino:avrdude
 ariadne1284W.bootloader.low_fuses=0xFF
-ariadne1284W.bootloader.high_fuses=0xD8
 ariadne1284W.bootloader.extended_fuses=0xFD
 ariadne1284W.bootloader.unlock_bits=0x3F
 ariadne1284W.bootloader.lock_bits=0x0F
@@ -185,6 +208,13 @@ ariadne1284W.build.f_cpu=16000000L
 ariadne1284W.build.core=arduino:arduino
 ariadne1284W.build.variant=bobuino
 ariadne1284W.build.board=1284P_STANDARD
+
+## Save EEPROM Settings
+## --------------------
+ariadne1284W.menu.eeprom.erase=Erase
+ariadne1284W.menu.eeprom.erase.bootloader.high_fuses=0xD8
+ariadne1284W.menu.eeprom.save=Save
+ariadne1284W.menu.eeprom.save.bootloader.high_fuses=0xD0
 
 ## Bootloader for 1284p with Wiznet W5100 chip
 ## ---------------------------------------------
@@ -216,7 +246,6 @@ ariadne32U4.upload.wait_for_upload_port=true
 
 ariadne32U4.bootloader.tool=arduino:avrdude
 ariadne32U4.bootloader.low_fuses=0xFF
-ariadne32U4.bootloader.high_fuses=0xD8
 ariadne32U4.bootloader.extended_fuses=0xCB
 ariadne32U4.bootloader.unlock_bits=0x3F
 ariadne32U4.bootloader.lock_bits=0x0F
@@ -226,6 +255,13 @@ ariadne32U4.build.f_cpu=16000000L
 ariadne32U4.build.core=arduino
 ariadne32U4.build.variant=leonardo
 ariadne32U4.build.board=AVR_LEONARDO
+
+## Save EEPROM Settings
+## --------------------
+ariadne32U4.menu.eeprom.erase=Erase
+ariadne32U4.menu.eeprom.erase.bootloader.high_fuses=0xD8
+ariadne32U4.menu.eeprom.save=Save
+ariadne32U4.menu.eeprom.save.bootloader.high_fuses=0xD0
 
 ## Bootloader for 32u4 with Wiznet W5100 chip
 ## ---------------------------------------------

--- a/docs/erase_eeprom.png
+++ b/docs/erase_eeprom.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8287b6b4f60495c2f03649fa65238778bd1e8ec5c944cc8e4e79c76706f327df
+size 251755


### PR DESCRIPTION
A new menu item has been added in the boards.txt configuration for the Ariadne bootloaders. This allows you to manually select whether the EEPROM contents are saved or erased when the bootloader is flashed. The old default of erasing the EEPROM contents is preserved.

Documentation has been updated accordingly.

Fixes #39