### PR TITLE
packaging for board manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ distclean:
 .PHONY: package
 package:
 	$(Q)tools/package.sh
+	$(Q)tools/package_bm.sh
 	$(Q) mv $(BUILDRESULTS)/release/athena_bootloaders.zip $(BUILDRESULTS)/release/athena_bootloaders-$(BUILD_TAG).zip
+	$(Q) mv $(BUILDRESULTS)/release/athena_bootloaders-bm.zip $(BUILDRESULTS)/release/athena_bootloaders-bm-$(BUILD_TAG).zip
 
 .PHONY: dist
 dist: $(CONFIGURED_BUILD_DEP)

--- a/package_athena-bootloader_index.json
+++ b/package_athena-bootloader_index.json
@@ -1,0 +1,51 @@
+{
+    "packages": [
+        {
+            "name": "Athena-Bootloader",
+            "maintainer": "Embedded Artistry",
+            "websiteURL": "https://github.com/embeddedartistry/athena-bootloader",
+            "email": "",
+            "help": {
+                "online": ""
+            },
+            "platforms": [
+                {
+                    "name": "Athena Bootloader",
+                    "architecture": "avr",
+                    "version": "11.3.22-RC1",
+                    "category": "Contributed",
+                    "help": {
+                        "online": "https://github.com/embeddedartistry/athena-bootloader"
+                    },
+                    "url": "https://github.com/hagaigold/athena-bootloader/releases/download/11.3.22.RC1/athena_bootloaders_package.zip",
+                    "archiveFileName": "athena_bootloaders_package.zip",
+                    "checksum": "SHA-256:5B93BE9E9E40EABD2427D1CEE211817BD4BA217B2D5D67B8B349A0336564D315",
+                    "size": "222288",
+                    "boards": [
+                        {
+                            "name": "Arduino Duemilanove w/ ATmega328"
+                        },
+                        {
+                            "name": "Arduino Uno"
+                        },
+                        {
+                            "name": "Arduino Ethernet"
+                        },
+                        {
+                            "name": "Arduino Mega 2560"
+                        },
+                        {
+                            "name": "ATmega1284P"
+                        },
+                        {
+                            "name": "ATmega32U4"
+                        }
+                    ],
+                    "toolsDependencies": []
+                }
+
+            ],
+            "tools": []
+        }
+    ]
+}

--- a/tools/package_bm.sh
+++ b/tools/package_bm.sh
@@ -9,7 +9,7 @@ PACKAGE_NAME=athena-bootloader
 rm -rf ${PACKAGE_TMP_DIR}
 
 mkdir -p ${PACKAGE_TMP_DIR}/${PACKAGE_NAME}
-cp -r avr/* ${PACKAGE_TMP_DIR}/${PACKAGE_NAME}
+cp -rp avr/* ${PACKAGE_TMP_DIR}/${PACKAGE_NAME}
 
 cd ${PACKAGE_TMP_DIR}
 zip -r $OLDPWD/${OUTPUT_DIR}/athena_bootloaders-bm.zip ${PACKAGE_NAME}

--- a/tools/package_bm.sh
+++ b/tools/package_bm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create package for board manager (package_AB_index.json) with the required directory structure
+
+OUTPUT_DIR=./buildresults/release
+PACKAGE_TMP_DIR=./buildresults/tmp
+PACKAGE_NAME=athena-bootloader
+
+rm -rf ${PACKAGE_TMP_DIR}
+
+mkdir -p ${PACKAGE_TMP_DIR}/${PACKAGE_NAME}
+cp -r avr/* ${PACKAGE_TMP_DIR}/${PACKAGE_NAME}
+
+cd ${PACKAGE_TMP_DIR}
+zip -r $OLDPWD/${OUTPUT_DIR}/athena_bootloaders-bm.zip ${PACKAGE_NAME}


### PR DESCRIPTION
Part of #64.
for the board manager to work, we need a different packaging structure from what currently we do.

Working example for a [board manager](https://github.com/hagaigold/athena-bootloader/blob/develop/package_AB_index.json).
For testing it in Arduino IDE the `raw` version should be used- https://raw.githubusercontent.com/hagaigold/athena-bootloader/develop/package_AB_index.json